### PR TITLE
fix: remove tabs default margin

### DIFF
--- a/src/components/page-container/index.vue
+++ b/src/components/page-container/index.vue
@@ -62,7 +62,7 @@ function renderTitle(title: VNodeChild | (() => VNodeChild)) {
 
 <template>
   <div>
-    <div class="bg-[var(--bg-color)]" px-24px pb-16px mb-24px mx--24px mt--24px>
+    <div class="bg-[var(--bg-color)]" px-24px py-16px mb-24px mx--24px mt--24px>
       <a-breadcrumb v-if="!currentItem.hideInBreadcrumb">
         <template v-if="currentItem.matched?.length">
           <a-breadcrumb-item v-for="item in currentItem.matched" :key="item.path">

--- a/src/layouts/multi-tab/index.vue
+++ b/src/layouts/multi-tab/index.vue
@@ -187,5 +187,8 @@ onUnmounted(() => {
   .ant-tabs-nav-operations {
     display: none !important;
   }
+  .ant-tabs-nav {
+    margin-bottom: 0;
+  }
 }
 </style>


### PR DESCRIPTION
## 问题

关闭多页签后，页面和header之间没了边距，原有的边距是由antdv Tabs组件的默认margin-bottom提供的，page-container只设置了下边距，没有设置上边距，导致了取消Tabs后没了边距。

<img width="1305" alt="截屏2023-10-28 23 49 36" src="https://github.com/antdv-pro/antdv-pro/assets/16523012/b3ccb8a0-0d1d-4366-af57-380149d30adc">

## 解决

将page-container的上下边距统一，去除Tabs组件默认的下边距可以解决这个问题。而且Tabs的默认边距给不同背景的页面增加了一道白条，也不太好看。

这种解决方式不知道会不会影响其他功能，有没有更好的方式解决。

