### PR TITLE
feat: add afterQuery fn for table-query.ts

### DIFF
--- a/src/composables/table-query.ts
+++ b/src/composables/table-query.ts
@@ -74,6 +74,10 @@ export interface TableQueryOptions {
    * 查询前回调
    */
   beforeQuery: () => void
+  /**
+   * 查询后回调
+   */
+  afterQuery: () => void
 }
 
 /**
@@ -117,6 +121,9 @@ export function useTableQuery(_options: Partial<TableQueryOptions>) {
     },
     beforeQuery() {
     },
+    afterQuery(data) {
+      return data
+    },
   }, _options))
 
   // 查询方法
@@ -134,8 +141,9 @@ export function useTableQuery(_options: Partial<TableQueryOptions>) {
         order: state.pagination.order,
         ...state.queryParams,
       })
-      state.dataSource = data.records ?? []
-      state.pagination.total = data.total ?? 0
+      const _data = await state.afterQuery(data)
+      state.dataSource = _data.records ?? []
+      state.pagination.total = _data.total ?? 0
     }
     catch (e) {
       throw new Error(`Query Failed: ${e}`)

--- a/src/composables/table-query.ts
+++ b/src/composables/table-query.ts
@@ -37,7 +37,7 @@ export interface TableQueryOptions {
   /**
    *查询接口
    */
-  queryApi: (params: any) => Promise<any>
+  queryApi: <R = any, T = any>(params?: T) => Promise<R>
   /**
    * 是否加载中
    */
@@ -77,7 +77,7 @@ export interface TableQueryOptions {
   /**
    * 查询后回调
    */
-  afterQuery: () => void
+  afterQuery: <R = any>(data: R) => typeof data
 }
 
 /**
@@ -121,7 +121,7 @@ export function useTableQuery(_options: Partial<TableQueryOptions>) {
     },
     beforeQuery() {
     },
-    afterQuery(data) {
+    afterQuery(data: TablePaginationProps) {
       return data
     },
   }, _options))

--- a/src/composables/table-query.ts
+++ b/src/composables/table-query.ts
@@ -1,6 +1,7 @@
 import type { PaginationProps } from 'ant-design-vue'
 import type { TableRowSelection } from 'ant-design-vue/es/table/interface'
 import { assign } from 'lodash'
+import type { ResponseBody } from '~@/utils/request'
 
 /**
  * 表格分页扩展类型
@@ -37,7 +38,7 @@ export interface TableQueryOptions {
   /**
    *查询接口
    */
-  queryApi: <R = any, T = any>(params?: T) => Promise<R>
+  queryApi: (params?: any) => Promise<ResponseBody<any>>
   /**
    * 是否加载中
    */

--- a/src/pages/list/crud-table.vue
+++ b/src/pages/list/crud-table.vue
@@ -33,6 +33,10 @@ const { state, initQuery, resetQuery, query } = useTableQuery({
     value: undefined,
     remark: undefined,
   },
+  afterQuery: (res) => {
+    console.log(res)
+    return res
+  },
 })
 
 const crudTableModal = ref<InstanceType<typeof CrudTableModal>>()


### PR DESCRIPTION
Now, you can deal sth with `afterQuery()` after the `query()` call ends.

eg: 
```js
const { state, initQuery, resetQuery, query } = useTableQuery({
  queryApi: getListApi,
  queryParams: {
    name: undefined,
    value: undefined,
    remark: undefined,
  },
  afterQuery(data){
    // do sth...
    return data
  }
})
```
