### PR TITLE
fix: i18n-ally extension setting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -67,8 +67,12 @@
     "toml"
   ],
   "i18n-ally.localesPaths": [
-    "src/locales",
-    "src/locales/lang",
+    "src/locales/lang/global",
+    "src/locales/lang/pages",
     "src/pages/common/locales"
-  ]
+  ],
+  "i18n-ally.enabledParsers": ["ts"],
+  "i18n-ally.parsers.typescript.compilerOptions": {
+    "moduleResolution": "node"
+  }
 }


### PR DESCRIPTION
fixed the issue where the i18n-ally plugin failed to read language files.