### PR TITLE
chore: i18n ally ext's  config compatibility，remove vite v6 invalid opts

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["johnsoncodehk.volarjs-labs","Vue.volar"]
+  "recommendations": ["johnsoncodehk.volarjs-labs", "Vue.volar", "lokalise.i18n-ally"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -45,5 +45,20 @@
     "scss",
     "pcss",
     "postcss"
-  ]
+  ],
+
+  // Extensions：i18n Ally
+  // "i18n-ally.autoDetection": true,
+  "i18n-ally.localesPaths": [
+    "src/locales/lang/global",
+    "src/locales/lang/pages",
+    "src/pages/common/locales"
+  ],
+  // "i18n-ally.keystyle": "flat",
+  // "i18n-ally.sourceLanguage": "en-US",
+  // "i18n-ally.displayLanguage": "zh-CN",
+  "i18n-ally.enabledParsers": ["ts"],
+  "i18n-ally.parsers.typescript.compilerOptions": {
+    "moduleResolution": "node" // 配置解析策略
+  }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -103,9 +103,9 @@ export default ({ mode }: ConfigEnv): UserConfig => {
         // },
       },
     },
-    test: {
-      globals: true,
-      environment: 'jsdom',
-    },
+    // test: {
+    //   globals: true,
+    //   environment: 'jsdom',
+    // },
   }
 }


### PR DESCRIPTION
chore: 对i18n ally扩展的配置兼容（直接clone并install后的工程无法正常在插件内显示出语言的概览及分析情况）在使用i18n-ally的插件前提下...同时移除vite latest即项目当前版内失效的选项配置“test”（主要是爆红了有点看不下去了……）。