### PR TITLE
fix: the newly added tag theme is not working on the dark background of the personal center

### DIFF
--- a/src/pages/account/center.vue
+++ b/src/pages/account/center.vue
@@ -128,7 +128,7 @@ const teamData = ref<ITeamDataItem[]>([
               @blur="handleInputConfirm"
               @keyup.enter="handleInputConfirm"
             />
-            <a-tag v-else style="background: #fff; border-style: dashed" @click="showInput">
+            <a-tag v-else style="border-style: dashed" @click="showInput">
               <PlusOutlined />
             </a-tag>
           </div>


### PR DESCRIPTION
| before | after |
| ------- | ----- |
| <img width="615" height="636" alt="image" src="https://github.com/user-attachments/assets/e68851ee-22ab-43c3-b15a-5c007f2a8eca" /> | <img width="606" height="780" alt="image" src="https://github.com/user-attachments/assets/0d3bf7ec-1614-4c07-a3a8-6d4fbb24920b" /> |
