### PR TITLE
perf: 优化路由拦截器中的errorHandler响应到401（鉴权失败）状态码时路由器追加返回redirect的问题

### DIFF
--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -66,11 +66,13 @@ function errorHandler(error: AxiosError): Promise<any> {
        * 这里处理清空用户信息和token的逻辑，后续扩展
        */
       token.value = null
+
+      const { fullPath, query: { redirect } } = router.currentRoute.value
       router
         .push({
           path: '/login',
           query: {
-            redirect: router.currentRoute.value.fullPath,
+            redirect: redirect || fullPath,
           },
         })
         .then(() => {})


### PR DESCRIPTION
perf: 优化路由拦截器中的errorHandler，“一旦响应到401（鉴权失败）状态码并跳转到登录页后，此时若在登录页仍然登录失败（命中401时）的话会导致地址栏再次追加redirect，持续登录401的话则会在地址栏无限追加redirect”的问题